### PR TITLE
Fix `ModuleNotFoundError` in fix_pkg_resources branch build

### DIFF
--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,8 +1,0 @@
-"""
-Placeholder to to suppress `Error: Process completed with exit code 5`,
-which occurs when no tests run. Remove this file when real tests are added.
-"""
-
-
-def test_placeholder():
-    pass


### PR DESCRIPTION
Add `__init__.py` to tests directory
- Fixes import issues with `test_resources.py`
- Remove `test_placeholder.py`